### PR TITLE
Remove empty comments

### DIFF
--- a/src/tokenize.coffee
+++ b/src/tokenize.coffee
@@ -17,7 +17,7 @@ module.exports = tokenize = (input) ->
   debug 'input', input
 
   # remove comments
-  input = input.replace /#.+/igm, ''
+  input = input.replace /#.*/igm, ''
   input = input.replace ///
     ".+?"|\/\*[\s\S]*?\*\/|\/\/.*
   ///gm, (match) ->

--- a/test/hcl-samples-json.coffee
+++ b/test/hcl-samples-json.coffee
@@ -575,4 +575,10 @@ module.exports = [{
            ]
        }
    }
-}]
+}
+
+{
+  int: 123,
+  foo: "bar"
+}
+]

--- a/test/hcl-samples.coffee
+++ b/test/hcl-samples.coffee
@@ -537,4 +537,10 @@ group "test" {
 }
 """
 
+"""
+int = 123
+# Padded comment
+#
+foo = "bar"
+"""
 ]


### PR DESCRIPTION
Before empty comments would make the `#` be the key and cause unexpected behaviour.

Demo:
https://runkit.com/embed/zu0fx5fj7xif